### PR TITLE
require version 2.3+ of symfony/options-resolver & symfony/yaml to support symfony2 lts 2.3 (#1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "psr-0": { "": "src/"  }
     },
     "require": {
-        "symfony/options-resolver": "~2.4",
-        "symfony/yaml": "~2.4"
+        "symfony/options-resolver": "~2.3",
+        "symfony/yaml": "~2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "*",


### PR DESCRIPTION
in composer.json you require symfony 2.4+ packages. do you really need the 2.4+ versions of:

symfony/options-resolver
symfony/yaml

there do not seem to be mayor updates, which prevent to rely on version 2.3+ of the listed packages.

by relying on 2.3+ you are able to use you package in symfony 2.3 environment. symfony 2.3 is the first long term release. thus it would be great to support it. :)
