### PR TITLE
Use the new function signature of setAllowedTypes and fix for broken test

### DIFF
--- a/src/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggleGeneric.php
+++ b/src/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggleGeneric.php
@@ -25,11 +25,7 @@ class FeatureToggleGeneric extends FeatureToggle
             )
         );
 
-        $resolver->setAllowedTypes(
-            array(
-                'enabled' => 'bool',
-            )
-        );
+        $resolver->setAllowedTypes('enabled', 'bool');
     }
 
     /**

--- a/tests/JoshuaEstes/Component/FeatureToggle/FeatureTest.php
+++ b/tests/JoshuaEstes/Component/FeatureToggle/FeatureTest.php
@@ -25,7 +25,7 @@ class FeatureTest extends \PHPUnit_Framework_TestCase
 
     public function testWithConstructorArgument()
     {
-        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
 
         $feature = new Feature(
             array(


### PR DESCRIPTION
Symfony throws the following exception when you try to create a new instance of GenericFeatureToggle, because it does not use the new signature for setAllowed types:

```Calling the Symfony\Component\OptionsResolver\OptionsResolver::setAllowedTypes method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.```

And Symfony also seems to have changed the type of ```Symfony\Component\OptionsResolver\Exception\InvalidOptionsException``` to ```Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException```, which broke the ```FeatureTest::testWithConstructorArgument``` test.