### PR TITLE
Update OptionsResolver usage to be compatible with Symfony 2.7

### DIFF
--- a/docs/toggles/index.rst
+++ b/docs/toggles/index.rst
@@ -55,9 +55,9 @@ You can create a custom feature toggle with ease.
         /**
          * Used to set the options that are allowed to be used with this toggle
          *
-         * @param OptionsResolverInterface $resolver
+         * @param OptionsResolver $resolver
          */
-        protected function setDefaultOptions(OptionsResolverInterface $resolver)
+        protected function configureOptions(OptionsResolver $resolver)
         {
             $resolver->setRequired(
                 array(

--- a/src/JoshuaEstes/Component/FeatureToggle/Feature.php
+++ b/src/JoshuaEstes/Component/FeatureToggle/Feature.php
@@ -3,7 +3,6 @@
 namespace JoshuaEstes\Component\FeatureToggle;
 
 use JoshuaEstes\Component\FeatureToggle\Toggle\FeatureToggleInterface;
-use JoshuaEstes\Component\FeatureToggle\Toggle\FeatureToggleGeneric;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -41,17 +40,28 @@ class Feature implements FeatureInterface
     public function __construct(array $options = array())
     {
         $resolver = new OptionsResolver();
-        $this->setDefaultOptions($resolver);
+        $this->configureOptions($resolver);
         $this->options = $resolver->resolve($options);
     }
 
     /**
      * @param OptionsResolverInterface $resolver
+     *
+     * @deprecated use configureOptions instead
      */
     protected function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         // This is used when extending this class, you can set various
         // options here if need be.
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        // @TODO Remove this call when removing the setDefaultOptions method
+        $this->setDefaultOptions($resolver);
     }
 
     /**

--- a/src/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggle.php
+++ b/src/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggle.php
@@ -29,8 +29,20 @@ abstract class FeatureToggle implements FeatureToggleInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated use configureOptions instead
      */
-    abstract protected function setDefaultOptions(OptionsResolverInterface $resolver);
+    protected function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        $this->setDefaultOptions($resolver);
+    }
 
     /**
      * Set or modify an option after the object has been initialized
@@ -62,7 +74,7 @@ abstract class FeatureToggle implements FeatureToggleInterface
     private function resolve(array $options = array())
     {
         $resolver = new OptionsResolver();
-        $this->setDefaultOptions($resolver);
+        $this->configureOptions($resolver);
         $this->options = $resolver->resolve($options);
     }
 

--- a/src/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggleGeneric.php
+++ b/src/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggleGeneric.php
@@ -2,9 +2,8 @@
 
 namespace JoshuaEstes\Component\FeatureToggle\Toggle;
 
-use JoshuaEstes\Component\FeatureToggle\Toggle\FeatureToggle;
 use JoshuaEstes\Component\FeatureToggle\FeatureInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Used to easly add a feature that can be enabled or disabled
@@ -13,17 +12,12 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class FeatureToggleGeneric extends FeatureToggle
 {
-
     /**
      * {@inheritDoc}
      */
-    protected function setDefaultOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(
-            array(
-                'enabled' => false,
-            )
-        );
+        $resolver->setDefault('enabled', false);
 
         $resolver->setAllowedTypes('enabled', 'bool');
     }


### PR DESCRIPTION
* The `setDefaultOptions` of the `OptionsResolver` is deprecated, use `configureOptions` instead
* The `OptionsResolverInterface` is deprecated, use `OptionsResolver` instead

This change is backward compatible