### PR TITLE
Remove Symfony/Yaml dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     },
     "require": {
         "symfony/options-resolver": ">=2.3",
-        "symfony/yaml": ">=2.3",
         "doctrine/common": ">=2.4"
     },
     "require-dev": {


### PR DESCRIPTION
The Symfony/Yaml library isn't used in the library and shouldn't be a requirement.