### PR TITLE
Fix dependencies versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,14 @@
         "psr-0": { "": "src/"  }
     },
     "require": {
-        "symfony/options-resolver": ">=2.3",
-        "doctrine/common": ">=2.4"
+        "roave/security-advisories": "dev-master",
+        "symfony/options-resolver": "^2.3",
+        "doctrine/common": "^2.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
-        "phing/phing": "*",
-        "codeclimate/php-test-reporter": "*"
+        "phpunit/phpunit": "^5.4.6",
+        "phing/phing": "^2.15.2",
+        "codeclimate/php-test-reporter": "^0.3.2"
     },
     "extra": {
         "branch-alias": {
@@ -48,3 +49,4 @@
         ]
     }
 }
+


### PR DESCRIPTION
Because the `composer.json` versions were not locked just to patches, there were exposed to `BC`s. So the `symfony/options-resolver` package deprecated the `OptionsResolverInterface` and the package was broken. 