### PR TITLE
Feature: Support symfony/options-resolver 3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
         "psr-0": { "": "src/"  }
     },
     "require": {
-        "symfony/options-resolver": "~2.4",
-        "doctrine/common": "~2.4"
+        "symfony/options-resolver": "~2.6|~3.0",
+        "doctrine/common": "~2.4",
+        "doctrine/collections": "~1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.4",
+        "phpunit/phpunit": "~4.8",
         "phing/phing": "~2.15",
         "codeclimate/php-test-reporter": "^0.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         "psr-0": { "": "src/"  }
     },
     "require": {
-        "symfony/options-resolver": ">=2.3",
-        "doctrine/common": ">=2.4"
+        "symfony/options-resolver": "~2.4",
+        "doctrine/common": "~2.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
-        "phing/phing": "*",
-        "codeclimate/php-test-reporter": "*"
+        "phpunit/phpunit": "~5.4",
+        "phing/phing": "~2.15",
+        "codeclimate/php-test-reporter": "^0.3"
     },
     "extra": {
         "branch-alias": {

--- a/src/JoshuaEstes/Component/FeatureToggle/Feature.php
+++ b/src/JoshuaEstes/Component/FeatureToggle/Feature.php
@@ -4,7 +4,6 @@ namespace JoshuaEstes\Component\FeatureToggle;
 
 use JoshuaEstes\Component\FeatureToggle\Toggle\FeatureToggleInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Object that represents a feature in the system.
@@ -45,23 +44,10 @@ class Feature implements FeatureInterface
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
-     *
-     * @deprecated use configureOptions instead
-     */
-    protected function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        // This is used when extending this class, you can set various
-        // options here if need be.
-    }
-
-    /**
      * @param OptionsResolver $resolver
      */
     protected function configureOptions(OptionsResolver $resolver)
     {
-        // @TODO Remove this call when removing the setDefaultOptions method
-        $this->setDefaultOptions($resolver);
     }
 
     /**

--- a/src/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggle.php
+++ b/src/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggle.php
@@ -3,12 +3,11 @@
 namespace JoshuaEstes\Component\FeatureToggle\Toggle;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * All features should extend this class. This provides some defaults that
  * help with feature toggles
- * 
+ *
  * @author Joshua Estes <Joshua@Estes.in>
  */
 abstract class FeatureToggle implements FeatureToggleInterface
@@ -29,19 +28,9 @@ abstract class FeatureToggle implements FeatureToggleInterface
 
     /**
      * {@inheritDoc}
-     *
-     * @deprecated use configureOptions instead
-     */
-    protected function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-    }
-
-    /**
-     * {@inheritDoc}
      */
     protected function configureOptions(OptionsResolver $resolver)
     {
-        $this->setDefaultOptions($resolver);
     }
 
     /**

--- a/tests/JoshuaEstes/Component/FeatureToggle/FeatureBuilderTest.php
+++ b/tests/JoshuaEstes/Component/FeatureToggle/FeatureBuilderTest.php
@@ -7,7 +7,8 @@ class FeatureBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testNewFeature()
     {
-        $toggle = $this->getMock('JoshuaEstes\Component\FeatureToggle\Toggle\FeatureToggleInterface');
+        $toggle = $this->getMockBuilder('JoshuaEstes\Component\FeatureToggle\Toggle\FeatureToggleInterface')
+            ->getMock();
 
         $feature = FeatureBuilder::create()
             ->setKey('test_feature')

--- a/tests/JoshuaEstes/Component/FeatureToggle/FeatureTest.php
+++ b/tests/JoshuaEstes/Component/FeatureToggle/FeatureTest.php
@@ -15,7 +15,9 @@ class FeatureTest extends \PHPUnit_Framework_TestCase
 
     public function testWithToggle()
     {
-        $toggle = $this->getMock('JoshuaEstes\Component\FeatureToggle\Toggle\FeatureToggleInterface');
+        $toggle = $this->getMockBuilder('JoshuaEstes\Component\FeatureToggle\Toggle\FeatureToggleInterface')
+            ->getMock();
+
         $feature = new Feature();
         $feature
             ->setKey('test_feature')

--- a/tests/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggleGenericTest.php
+++ b/tests/JoshuaEstes/Component/FeatureToggle/Toggle/FeatureToggleGenericTest.php
@@ -8,7 +8,8 @@ class FeatureToggleGenericTest extends \PHPUnit_Framework_TestCase
     public function testEnabled()
     {
         $toggle = new FeatureToggleGeneric(array('enabled'=>true));
-        $feature = $this->getMock('JoshuaEstes\Component\FeatureToggle\FeatureInterface');
+        $feature = $this->getMockBuilder('JoshuaEstes\Component\FeatureToggle\FeatureInterface')
+            ->getMock();
 
         $this->assertTrue($toggle->isEnabled($feature));
     }
@@ -16,7 +17,8 @@ class FeatureToggleGenericTest extends \PHPUnit_Framework_TestCase
     public function testDisabled()
     {
         $toggle = new FeatureToggleGeneric(array('enabled'=>false));
-        $feature = $this->getMock('JoshuaEstes\Component\FeatureToggle\FeatureInterface');
+        $feature = $this->getMockBuilder('JoshuaEstes\Component\FeatureToggle\FeatureInterface')
+            ->getMock();
 
         $this->assertFalse($toggle->isEnabled($feature));
     }


### PR DESCRIPTION
Hi @JoshuaEstes,

I updated some dependencies and removed some deprecations. My goal is to bring comparability with symfony/options-resolver in version 3 but support the 2 versions as well.

What do you think? 
Have a nice day
Sven

Steps done:

- Pin composer dependencies for packages
- Fix phpunit deprecations for getMock
- Fix deprecations for symfony/options-resolver
- Removed setDefaultOptions, **BC break!** for package users
- Ensure compability with symfony/options-resolver version bigger, but including, than 2.6.

**symfony/options-resolver 2.6 compability:**
```$ composer info | grep symfony/options-resolver; bin/phpunit tests

symfony/options-resolver  v2.6.0  Symfony OptionsResolver Component

PHPUnit 5.7.20 by Sebastian Bergmann and contributors.

................ 16 / 16 (100%)

Time: 34 ms, Memory: 4.00MB

OK (16 tests, 23 assertions)
```

**symfony/options-resolver 3.3 compability:**
```
symfony/options-resolver  v3.3.2  Symfony OptionsResolver Component

PHPUnit 5.7.20 by Sebastian Bergmann and contributors.

................ 16 / 16 (100%)

Time: 30 ms, Memory: 4.00MB

OK (16 tests, 23 assertions)
```
